### PR TITLE
Allow setting porcupine as your default browser

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -7,8 +7,6 @@ git clone https://github.com/micahflee/porcupine.git
 cd porcupine
 ```
 
-## Linux
-
 Install the needed dependencies:
 
 For Debian-like distros: `apt install -y build-essential fakeroot python3-all python3-stdeb dh-python python3-pyqt5`
@@ -27,7 +25,3 @@ You can also build porcupine packages to install:
 Create a .deb on Debian-like distros: `./install/build_deb.sh`
 
 Create a .rpm on Fedora-like distros: `./install/build_rpm.sh`
-
-# macOS and Windows
-
-Probably coming soon...

--- a/BUILD.md
+++ b/BUILD.md
@@ -13,7 +13,8 @@ For Debian-like distros: `apt install -y build-essential fakeroot python3-all py
 
 For Fedora-like distros: `dnf install -y rpm-build python3-qt5`
 
-You can run porcupine without installing it:
+You can run porcupine without installing it (note that without installing it, you
+cannot set it as your default browser):
 
 ```sh
 ./porcupine

--- a/README.md
+++ b/README.md
@@ -3,5 +3,3 @@
 Set porcupine as your default web browser. When you click a link, porcupine will copy the URL to your clipboard and notify you about this. Or it can run a command of your choice. This way you'll never accidentally open a link you don't want to, and you can easily choose which browser to load it in.
 
 To build from source, see [these instructions](BUILD.md).
-
-After installing, you can set porcupine as your default browser in Linux by typing: `xdg-settings set default-web-browser porcupine.desktop`

--- a/porcupine
+++ b/porcupine
@@ -138,8 +138,9 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
 
     def update_ui(self):
         # Is porcupine the default browser?
-        default_browser = subprocess.check_output(['xdg-settings', 'get', 'default-web-browser']).strip()
-        if default_browser == b'porcupine.desktop':
+        default_browser_http = subprocess.check_output(['xdg-settings', 'get', 'default-url-scheme-handler', 'http']).strip()
+        default_browser_https = subprocess.check_output(['xdg-settings', 'get', 'default-url-scheme-handler', 'https']).strip()
+        if default_browser_http == default_browser_https == b'porcupine.desktop':
             self.default_browser_group.hide()
         else:
             self.default_browser_group.show()
@@ -164,7 +165,8 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
         self.close()
 
     def set_default_browser(self):
-        subprocess.call(['xdg-settings', 'set', 'default-web-browser', 'porcupine.desktop'])
+        subprocess.call(['xdg-settings', 'set', 'default-url-scheme-handler', 'http', 'porcupine.desktop'])
+        subprocess.call(['xdg-settings', 'set', 'default-url-scheme-handler', 'https', 'porcupine.desktop'])
         self.update_ui()
 
 

--- a/porcupine
+++ b/porcupine
@@ -146,8 +146,9 @@ def main():
     app = QtWidgets.QApplication(sys.argv)
 
     if args.url is None:
-        # No arguments, open the settings dialog
-        PorcupineSettingsWindow(app, settings)
+        # No arguments, open the settings dialog. Even though settings_window is
+        # never used later, we must keep a reference to it
+        settings_window = PorcupineSettingsWindow(app, settings)
 
     else:
         # Start the system tray

--- a/porcupine
+++ b/porcupine
@@ -119,6 +119,7 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
 
         # Set the layout
         layout = QtWidgets.QVBoxLayout()
+        layout.setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
         layout.addWidget(label)
         layout.addWidget(self.radio_clipboard)
         layout.addWidget(self.radio_command)

--- a/porcupine
+++ b/porcupine
@@ -87,17 +87,26 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
         self.edit_command = QtWidgets.QLineEdit()
         self.edit_command.setPlaceholderText('for example: qvm-open-in-dvm %U')
         self.edit_command.setText(s['cmd'])
-        self.default_browser_label = QtWidgets.QLabel("Porcipine isn't your default browser")
-        self.default_browser_label.setStyleSheet('QLabel { font-weight: bold; }')
 
-        # Buttons
+        # Button
         self.save_button = QtWidgets.QPushButton("Save Settings")
         self.save_button.clicked.connect(self.save_settings)
-        self.default_browser_button = QtWidgets.QPushButton("Set as Default")
-        self.default_browser_button.clicked.connect(self.set_default_browser)
         buttons_layout = QtWidgets.QHBoxLayout()
         buttons_layout.addWidget(self.save_button)
-        buttons_layout.addWidget(self.default_browser_button)
+        buttons_layout.addStretch()
+
+        # Default browser
+        default_browser_label = QtWidgets.QLabel("Porcupine isn't your default browser")
+        default_browser_label.setStyleSheet('QLabel { font-size: 13px; }')
+        default_browser_button = QtWidgets.QPushButton("Set as default")
+        default_browser_button.setStyleSheet('QPushButton { font-size: 13px; font-weight: bold; }')
+        default_browser_button.clicked.connect(self.set_default_browser)
+        default_browser_layout = QtWidgets.QHBoxLayout()
+        default_browser_layout.addWidget(default_browser_label)
+        default_browser_layout.addWidget(default_browser_button)
+        default_browser_layout.addStretch()
+        self.default_browser_group = QtWidgets.QGroupBox()
+        self.default_browser_group.setLayout(default_browser_layout)
 
         # Choose the default action
         if s['action'] == 'clipboard':
@@ -115,8 +124,9 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
         layout.addWidget(self.radio_command)
         layout.addWidget(self.edit_command)
         layout.addStretch()
-        layout.addWidget(self.default_browser_label)
         layout.addLayout(buttons_layout)
+        layout.addStretch()
+        layout.addWidget(self.default_browser_group)
         central_widget = QtWidgets.QWidget()
         central_widget.setLayout(layout)
         self.setCentralWidget(central_widget)
@@ -129,11 +139,9 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
         # Is porcupine the default browser?
         default_browser = subprocess.check_output(['xdg-settings', 'get', 'default-web-browser']).strip()
         if default_browser == b'porcupine.desktop':
-            self.default_browser_label.hide()
-            self.default_browser_button.hide()
+            self.default_browser_group.hide()
         else:
-            self.default_browser_label.show()
-            self.default_browser_button.show()
+            self.default_browser_group.show()
 
         # Only update the UI if it has been built
         if hasattr(self, 'radio_clipboard') and hasattr(self, 'radio_command') and hasattr(self, 'edit_command'):

--- a/porcupine
+++ b/porcupine
@@ -84,18 +84,28 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
         self.radio_clipboard.toggled.connect(self.toggle)
         self.radio_command = QtWidgets.QRadioButton('Run command with the URL')
         self.radio_command.toggled.connect(self.toggle)
+        self.edit_command = QtWidgets.QLineEdit()
+        self.edit_command.setPlaceholderText('for example: qvm-open-in-dvm %U')
+        self.edit_command.setText(s['cmd'])
+        self.default_browser_label = QtWidgets.QLabel("Porcipine isn't your default browser")
+        self.default_browser_label.setStyleSheet('QLabel { font-weight: bold; }')
+
+        # Buttons
+        self.save_button = QtWidgets.QPushButton("Save Settings")
+        self.save_button.clicked.connect(self.save_settings)
+        self.default_browser_button = QtWidgets.QPushButton("Set as Default")
+        self.default_browser_button.clicked.connect(self.set_default_browser)
+        buttons_layout = QtWidgets.QHBoxLayout()
+        buttons_layout.addWidget(self.save_button)
+        buttons_layout.addWidget(self.default_browser_button)
+
+        # Choose the default action
         if s['action'] == 'clipboard':
             self.radio_clipboard.setChecked(True)
             self.radio_command.setChecked(False)
         else:
             self.radio_clipboard.setChecked(False)
             self.radio_command.setChecked(True)
-        self.edit_command = QtWidgets.QLineEdit()
-        self.edit_command.setPlaceholderText('for example: qvm-open-in-dvm %U')
-        self.edit_command.setText(s['cmd'])
-        button_save = QtWidgets.QPushButton("Save Settings")
-        button_save.clicked.connect(self.save_settings)
-
         self.update_ui()
 
         # Set the layout
@@ -105,7 +115,8 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
         layout.addWidget(self.radio_command)
         layout.addWidget(self.edit_command)
         layout.addStretch()
-        layout.addWidget(button_save)
+        layout.addWidget(self.default_browser_label)
+        layout.addLayout(buttons_layout)
         central_widget = QtWidgets.QWidget()
         central_widget.setLayout(layout)
         self.setCentralWidget(central_widget)
@@ -115,12 +126,23 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
         self.update_ui()
 
     def update_ui(self):
+        # Is porcupine the default browser?
+        default_browser = subprocess.check_output(['xdg-settings', 'get', 'default-web-browser']).strip()
+        if default_browser == b'porcupine.desktop':
+            self.default_browser_label.hide()
+            self.default_browser_button.hide()
+        else:
+            self.default_browser_label.show()
+            self.default_browser_button.show()
+
         # Only update the UI if it has been built
         if hasattr(self, 'radio_clipboard') and hasattr(self, 'radio_command') and hasattr(self, 'edit_command'):
             if self.radio_clipboard.isChecked():
                 self.edit_command.hide()
             if self.radio_command.isChecked():
                 self.edit_command.show()
+
+        self.adjustSize()
 
     def save_settings(self):
         if self.radio_clipboard.isChecked():
@@ -131,6 +153,10 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
 
         self.settings.save(action, cmd)
         self.close()
+
+    def set_default_browser(self):
+        subprocess.call(['xdg-settings', 'set', 'default-web-browser', 'porcupine.desktop'])
+        self.update_ui()
 
 
 def main():

--- a/porcupine
+++ b/porcupine
@@ -1,21 +1,11 @@
 #!/usr/bin/env python3
-import argparse, sys, os, json, subprocess, platform, inspect
+import argparse, sys, os, json, subprocess, inspect
 from PyQt5 import Qt, QtWidgets, QtCore
 
 def get_icon_path():
-    p = platform.system()
-
-    if p == 'Linux' and sys.argv and sys.argv[0].startswith(sys.prefix):
-        # Porcupine is installed systemwide in Linux
+    if sys.argv and sys.argv[0].startswith(sys.prefix):
+        # Porcupine is installed systemwide
         prefix = os.path.join(sys.prefix, 'share/pixmaps')
-
-    elif getattr(sys, 'frozen', False):
-        # Check if app is "frozen"
-        # https://pythonhosted.org/PyInstaller/#run-time-information
-        if p == 'Darwin':
-            prefix = os.path.join(sys._MEIPASS, 'share')
-        elif p == 'Windows':
-            prefix = os.path.join(os.path.dirname(sys.executable), 'share')
 
     else:
         # Look for share directory relative to python file
@@ -33,14 +23,7 @@ def delay(app, milliseconds):
 
 class Settings(object):
     def __init__(self):
-        p = platform.system()
-        if p == 'Windows':
-            appdata = os.environ['APPDATA']
-            self.path = '{}\\Porcupine\\porcupine.json'.format(appdata)
-        elif p == 'Darwin':
-            self.path = os.path.expanduser('~/Library/Application Support/Porcupine/porcupine.json')
-        else:
-            self.path = os.path.expanduser('~/.config/porcupine.json')
+        self.path = os.path.expanduser('~/.config/porcupine.json')
 
     def load(self):
         use_default = False

--- a/porcupine
+++ b/porcupine
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
-import argparse, sys, os, json, subprocess, inspect
+import argparse
+import sys
+import os
+import json
+import subprocess
+import inspect
 from PyQt5 import Qt, QtWidgets, QtCore
+
 
 def get_icon_path():
     if sys.argv and sys.argv[0].startswith(sys.prefix):
@@ -13,13 +19,16 @@ def get_icon_path():
 
     return os.path.join(prefix, "porcupine.png")
 
+
 def validate_url(url):
     return (url.lower().startswith('http://') or url.lower().startswith('https://'))
+
 
 def delay(app, milliseconds):
     time = QtCore.QTime.currentTime().addMSecs(milliseconds)
     while (QtCore.QTime.currentTime() < time):
         app.processEvents()
+
 
 class Settings(object):
     def __init__(self):
@@ -55,6 +64,7 @@ class Settings(object):
             pass
 
         json.dump(settings, open(self.path, 'w'))
+
 
 class PorcupineSettingsWindow(QtWidgets.QMainWindow):
     def __init__(self, app, settings):
@@ -121,6 +131,7 @@ class PorcupineSettingsWindow(QtWidgets.QMainWindow):
         self.settings.save(action, cmd)
         self.close()
 
+
 def main():
     # Parse arguments
     parser = argparse.ArgumentParser()
@@ -135,7 +146,7 @@ def main():
 
     if args.url is None:
         # No arguments, open the settings dialog
-        settings_window = PorcupineSettingsWindow(app, settings)
+        PorcupineSettingsWindow(app, settings)
 
     else:
         # Start the system tray
@@ -158,7 +169,7 @@ def main():
             else:
                 # Launch subprocess
                 cmd = s['cmd'].split()
-                cmd = [url if x=='%U' else x for x in cmd]
+                cmd = [url if x == '%U' else x for x in cmd]
                 try:
                     subprocess.call(cmd)
                 except:
@@ -175,6 +186,7 @@ def main():
         timer.start(4000)
 
     sys.exit(app.exec_())
+
 
 if __name__ == '__main__':
     main()

--- a/porcupine
+++ b/porcupine
@@ -5,6 +5,7 @@ import os
 import json
 import subprocess
 import inspect
+import signal
 from PyQt5 import Qt, QtWidgets, QtCore
 
 
@@ -184,6 +185,9 @@ def main():
         timer = QtCore.QTimer()
         timer.timeout.connect(quit)
         timer.start(4000)
+
+    # Allow ctrl-c to work
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     sys.exit(app.exec_())
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, sys, platform
+import os, sys
 
 version_file = os.path.join(os.path.dirname(__file__), 'share', 'version')
 version = open(version_file).read().strip().lstrip('v')
@@ -12,19 +12,15 @@ author_email = 'micah@micahflee.com'
 url = 'https://github.com/micahflee/porcupine'
 license = 'GPL v3'
 
-if platform.system() == 'Linux':
-    from setuptools import setup
-    setup(
-        name='porcupine', version=version,
-        description=description, long_description=long_description,
-        author=author, author_email=author_email,
-        url=url, license=license,
-        scripts=['porcupine'],
-        data_files=[
-            (os.path.join(sys.prefix, 'share/applications'), ['share/porcupine.desktop']),
-            (os.path.join(sys.prefix, 'share/pixmaps'), ['share/porcupine.png'])
-        ]
-    )
-
-else:
-    print('Unsupported platform')
+from setuptools import setup
+setup(
+    name='porcupine', version=version,
+    description=description, long_description=long_description,
+    author=author, author_email=author_email,
+    url=url, license=license,
+    scripts=['porcupine'],
+    data_files=[
+        (os.path.join(sys.prefix, 'share/applications'), ['share/porcupine.desktop']),
+        (os.path.join(sys.prefix, 'share/pixmaps'), ['share/porcupine.png'])
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
-import os, sys
+import os
+import sys
+from setuptools import setup
 
 version_file = os.path.join(os.path.dirname(__file__), 'share', 'version')
 version = open(version_file).read().strip().lstrip('v')
 
-description = "Set porcupine as your default web browser. When you click a link, porcupine will copy the URL to your clipboard and notify you about this."
-long_description = description + " " + "Or it can run a command of your choice. This way you'll never accidentally open a link you don't want to, and you can easily choose which browser to load it in."
+description = ("Set porcupine as your default web browser. When you click a "
+               "link, porcupine will copy the URL to your clipboard and "
+               "notify you about this.")
+long_description = ("{} Or it can run a command of your choice. This way "
+                    "you'll never accidentally open a link you don't want to, "
+                    "and you can easily choose which browser to load it "
+                    "in.").format(description)
 
 author = 'Micah Lee'
 author_email = 'micah@micahflee.com'
 url = 'https://github.com/micahflee/porcupine'
 license = 'GPL v3'
 
-from setuptools import setup
 setup(
     name='porcupine', version=version,
     description=description, long_description=long_description,


### PR DESCRIPTION
Resolves #3.

This PR includes:

- Remove references to Windows and Mac. For now, porcupine is a Linux-only app
- Improve python styles
- Allows you to quit from the command line with Ctrl-C
- Finally, allows you to set porcupine as your default web browser (in Linux, of course)

Here's what the settings look like if it's not your default browser:

![screenshot_2018-04-06_17-20-27](https://user-images.githubusercontent.com/156128/38449044-40046514-39bf-11e8-96e7-20f433a90dc6.png)

And here's the settings if it is your default browser:

![screenshot_2018-04-06_17-24-15](https://user-images.githubusercontent.com/156128/38449062-5b920f70-39bf-11e8-84ea-407b5df6f789.png)
