### PR TITLE
Update desktop file to remove deprecated tags

### DIFF
--- a/share/porcupine.desktop
+++ b/share/porcupine.desktop
@@ -1,10 +1,9 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Porcupine
 Comment=This is a "web browser" that copies URLs to your clipboard
 Exec=porcupine %U
 Terminal=false
 Type=Application
-Icon=porcupine.png
+Icon=porcupine
 Categories=Network;WebBrowser;
 MimeType=x-scheme-handler/http;x-scheme-handler/https;


### PR DESCRIPTION
Fixes #8.

The couple tags removed and modified are deprecated, according to desktop-file-validate. This should bring things up to speed.